### PR TITLE
Write cucumber stories to test the behavior of the bug.

### DIFF
--- a/features/edit_catagories.feature
+++ b/features/edit_catagories.feature
@@ -1,0 +1,25 @@
+Feature: Edit categories
+  
+As an administrator
+In order to create and maintain blog categories
+I should be able to create new categories and view and edit existing categories
+
+Background:
+    Given the blog is set up
+	And I am logged into the admin panel
+
+Scenario: Creating a new category
+  
+  Given I am on the admin page
+  And I go to the new category page
+  Then I should see "Categories"
+  When I fill in "Name" with "Swim"
+  And I fill in "Keywords" with "Freestyle"
+  And I fill in "Permalink" with "Test Permalink"
+  And I fill in "Description" with "Water Sports"
+  And I press "Save"
+  Then I should see "Category was successfully saved"
+  And I should see "Swim"
+  And I should see "Freestyle"
+  And I should see "Test Permalink"
+  And I should see "Water Sports"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -17,6 +17,11 @@ module NavigationHelpers
       '/'
     when /^the new article page$/
       '/admin/content/new'
+    
+    when /^the admin page/
+      '/admin/'
+    when /^the new category page/
+      '/admin/categories/new'
 
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:


### PR DESCRIPTION
And I go to the new category page                   # features/step_definitions/web_steps.rb:72
      Couldn't find Category without an ID (ActiveRecord::RecordNotFound)
      ./app/controllers/admin/categories_controller.rb:28:in `new_or_edit'
      ./app/controllers/admin/categories_controller.rb:9:in `block (2 levels) in new'
      ./app/controllers/admin/categories_controller.rb:8:in `new'
      <internal:prelude>:10:in `synchronize'
      ./features/step_definitions/web_steps.rb:73:in `/^(?:|I )go to (.+)$/'
      features/edit_catagories.feature:14:in `And I go to the new category page'